### PR TITLE
Allow multiple releases of chart in the same cluster

### DIFF
--- a/charts/service-account-issuer-discovery/templates/cluster-role-binding.yaml
+++ b/charts/service-account-issuer-discovery/templates/cluster-role-binding.yaml
@@ -5,7 +5,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "name" . }}
+  name: {{ .Release.Namespace }}-{{ include "name" . }}
   labels:
     app.kubernetes.io/name: {{ include "name" . }}
 roleRef:


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow multiple releases of the chart to be deployed in the same cluster.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
