### PR TITLE
Allow mounting the kube-root-ca

### DIFF
--- a/charts/service-account-issuer-discovery/templates/deployment.yaml
+++ b/charts/service-account-issuer-discovery/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
           {{- toYaml .Values.resources | nindent 10 }}
         {{- if or ( or .Values.gardenerManagedDNS.enabled ( eq .Values.serviceType "LoadBalancer" ) ) .Values.tlsConfig.enabled }}
         volumeMounts:
-        {{- else if or .Values.kubeconfig .Values.serviceAccountTokenVolumeProjection.enabled }}
+        {{- else if or ( or .Values.kubeconfig .Values.serviceAccountTokenVolumeProjection.enabled ) .Values.automountKubeRootCa }}
         volumeMounts:
         {{- end }}
         {{- if or ( or .Values.gardenerManagedDNS.enabled ( eq .Values.serviceType "LoadBalancer" ) ) .Values.tlsConfig.enabled }}
@@ -79,9 +79,14 @@ spec:
           mountPath: /var/run/issuer-discovery/serviceaccount
           readOnly: true
         {{- end }}
+        {{- if .Values.automountKubeRootCA }}
+        - name: kube-root-ca
+          mountPath: /var/run/issuer-discovery/kube-root-ca
+          readOnly: true
+        {{- end }}
       {{- if or ( or .Values.gardenerManagedDNS.enabled ( eq .Values.serviceType "LoadBalancer" ) ) .Values.tlsConfig.enabled }}
       volumes:
-      {{- else if or .Values.kubeconfig .Values.serviceAccountTokenVolumeProjection.enabled }}
+      {{- else if or ( or .Values.kubeconfig .Values.serviceAccountTokenVolumeProjection.enabled ) .Values.automountKubeRootCA }}
       volumes:
       {{- end }}
       {{- if or ( or .Values.gardenerManagedDNS.enabled ( eq .Values.serviceType "LoadBalancer" ) ) .Values.tlsConfig.enabled }}
@@ -110,4 +115,11 @@ spec:
               {{- if .Values.serviceAccountTokenVolumeProjection.audience }}
               audience: {{ .Values.serviceAccountTokenVolumeProjection.audience }}
               {{- end }}
+      {{- end }}
+      {{- if .Values.automountKubeRootCA }}
+      - name: kube-root-ca
+        projected:
+          sources:
+          - configMap:
+              name: kube-root-ca.crt
       {{- end }}

--- a/charts/service-account-issuer-discovery/values.yaml
+++ b/charts/service-account-issuer-discovery/values.yaml
@@ -13,6 +13,9 @@ kubeconfig:
 
 automountServiceAccountToken: false
 
+# If this is set to true then kube-root-ca will be projected in the container at path "/var/run/issuer-discovery/kube-root-ca/ca.crt"
+automountKubeRootCA: false
+
 serviceAccountTokenVolumeProjection:
   enabled: false
   expirationSeconds: 3600


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow mounting the kube-root-ca into the discovery service container.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
