### PR TITLE
Added --version flag to show build info

### DIFF
--- a/cmd/service-account-issuer-discovery/main.go
+++ b/cmd/service-account-issuer-discovery/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -15,12 +16,14 @@ import (
 	"time"
 
 	"github.com/gardener/service-account-issuer-discovery/internal/app"
+	"github.com/gardener/service-account-issuer-discovery/internal/version"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (
+	buildInfo            = flag.Bool("version", false, "Build information for the currently running binary")
 	kubeconfig           = flag.String("kubeconfig", "", "Path to the kubeconfig file. If not specified in cluster kubeconfig will be used.")
 	hostname             = flag.String("hostname", "", "Hostname to serve the public keys on.")
 	certFile             = flag.String("cert-file", "", "Path to certificate file.")
@@ -32,6 +35,20 @@ var (
 
 func main() {
 	flag.Parse()
+
+	if *buildInfo {
+		info, err := version.GetBuildInfo()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		jsonInfo, err := json.Marshal(info)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("%s\n", jsonInfo)
+		return
+	}
 
 	restConfig, err := getRESTConfig()
 	if err != nil {

--- a/hack/get-build.sh
+++ b/hack/get-build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+
+PACKAGE_PATH="${1:-github.com/gardener/service-account-issuer-discovery/internal}"
+VERSION_PATH="${2:-$(dirname $0)/../VERSION}"
+VERSION_VERSIONFILE="$(cat "$VERSION_PATH")"
+VERSION="${EFFECTIVE_VERSION:-$VERSION_VERSIONFILE}"
+
+if [ "$(git status --porcelain 2>/dev/null | wc -l)" -gt 0 ]
+then
+	VERSION=${VERSION}-dirty
+fi
+
+echo "-X $PACKAGE_PATH/version.Version=$VERSION"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,56 @@
+package version
+
+import (
+	"errors"
+	"runtime/debug"
+)
+
+var (
+	Version string
+)
+
+type VCSInfo struct {
+	VCS          string
+	Revision     string
+	Date         string
+	TreeModified string
+}
+
+type Info struct {
+	Version   string
+	VCSInfo   VCSInfo
+	GoVersion string
+	Compiler  string
+	Platform  string
+}
+
+func GetBuildInfo() (*Info, error) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil, errors.New("version: Error in ReadBuildInfo")
+	}
+	result := &Info{
+		Version:   Version,
+		GoVersion: info.GoVersion,
+	}
+
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "-compiler":
+			result.Compiler = setting.Value
+		case "GOARCH":
+			result.Platform += setting.Value
+		case "GOOS":
+			result.Platform = setting.Value + "/" + result.Platform
+		case "vcs":
+			result.VCSInfo.VCS = setting.Value
+		case "vcs.revision":
+			result.VCSInfo.Revision = setting.Value
+		case "vcs.time":
+			result.VCSInfo.Date = setting.Value
+		case "vcs.modified":
+			result.VCSInfo.TreeModified = setting.Value
+		}
+	}
+	return result, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added flag --version which shows build info in json format:
<img width="645" alt="Screenshot 2022-08-03 at 15 56 14" src="https://user-images.githubusercontent.com/57963548/182613299-69f4bece-17ba-48c4-adfa-98813fd881b7.png">

**Which issue(s) this PR fixes**:
Fixes #8

**Special notes for your reviewer**:
In the Dockerfile before the build command I change to the directory of main.go because VCS info is missing in BuildInfo when running go build with a specified .go file https://togithub.com/golang/go/issues/51279
**Release note**: 
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
`--version ` flag that shows version information
```
