### PR TITLE
Added --version flag to show build info

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,3 @@
 
 /bin
 /testbin
-/charts

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,13 @@ WORKDIR /workspace
 COPY . .
 RUN go mod download
 
-# Get version
-RUN hack/get-build.sh > /tmp/build-flags
-
 # Build
-WORKDIR cmd/service-account-issuer-discovery
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags="$(cat /tmp/build-flags)" -o /workspace/service-account-issuer-discovery
+WORKDIR /workspace/cmd/service-account-issuer-discovery
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags="$(/workspace/hack/get-build.sh)" -o /workspace/service-account-issuer-discovery
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/service-account-issuer-discovery .
+COPY --from=builder /workspace/service-account-issuer-discovery /service-account-issuer-discovery
 # nonroot user https://github.com/GoogleContainerTools/distroless/blob/18b2d2c5ebfa58fe3e0e4ee3ffe0e2651ec0f7f6/base/base.bzl#L8
 USER 65532:65532
 

--- a/cmd/service-account-issuer-discovery/main.go
+++ b/cmd/service-account-issuer-discovery/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	buildInfo            = flag.Bool("version", false, "Build information for the currently running binary")
+	showVersion          = flag.Bool("version", false, "Print the server version information.")
 	kubeconfig           = flag.String("kubeconfig", "", "Path to the kubeconfig file. If not specified in cluster kubeconfig will be used.")
 	hostname             = flag.String("hostname", "", "Hostname to serve the public keys on.")
 	certFile             = flag.String("cert-file", "", "Path to certificate file.")
@@ -36,8 +36,8 @@ var (
 func main() {
 	flag.Parse()
 
-	if *buildInfo {
-		info, err := version.GetBuildInfo()
+	if *showVersion {
+		info, err := version.BuildInfo()
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -46,8 +46,8 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf("%s\n", jsonInfo)
-		return
+		fmt.Println(string(jsonInfo))
+		os.Exit(0)
 	}
 
 	restConfig, err := getRESTConfig()

--- a/cmd/service-account-issuer-discovery/main.go
+++ b/cmd/service-account-issuer-discovery/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -15,12 +16,14 @@ import (
 	"time"
 
 	"github.com/gardener/service-account-issuer-discovery/internal/app"
+	"github.com/gardener/service-account-issuer-discovery/internal/version"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (
+	buildInfo            = flag.Bool("version", false, "Build information for the currently running binary")
 	kubeconfig           = flag.String("kubeconfig", "", "Path to the kubeconfig file. If not specified in cluster kubeconfig will be used.")
 	hostname             = flag.String("hostname", "", "Hostname to serve the public keys on.")
 	certFile             = flag.String("cert-file", "", "Path to certificate file.")
@@ -32,6 +35,20 @@ var (
 
 func main() {
 	flag.Parse()
+
+	if *buildInfo {
+		info, err := version.GetBuildInfo()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		jsonInfo, err := json.Marshal(info)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("%s\n", jsonInfo)
+		return
+	}
 
 	restConfig, err := getRESTConfig()
 	if err != nil {

--- a/hack/get-build.sh
+++ b/hack/get-build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+#
 # SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/hack/get-build.sh
+++ b/hack/get-build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+
+PACKAGE_PATH="${1:-github.com/gardener/service-account-issuer-discovery/internal}"
+VERSION_PATH="${2:-$(dirname $0)/../VERSION}"
+VERSION_VERSIONFILE="$(cat "$VERSION_PATH")"
+VERSION="${EFFECTIVE_VERSION:-$VERSION_VERSIONFILE}"
+
+if [ "$(git status --porcelain 2>/dev/null | wc -l)" -gt 0 ]
+then
+	VERSION=${VERSION}-dirty
+fi
+
+echo "-X $PACKAGE_PATH/version.Version=$VERSION"

--- a/hack/get-build.sh
+++ b/hack/get-build.sh
@@ -1,28 +1,17 @@
-#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
 #
-# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 PACKAGE_PATH="${1:-github.com/gardener/service-account-issuer-discovery/internal}"
 VERSION_PATH="${2:-$(dirname $0)/../VERSION}"
 VERSION_VERSIONFILE="$(cat "$VERSION_PATH")"
-VERSION="${EFFECTIVE_VERSION:-$VERSION_VERSIONFILE}"
+VERSION="${VERSION_VERSIONFILE}-$(git rev-parse HEAD)"
 
 if [ "$(git status --porcelain 2>/dev/null | wc -l)" -gt 0 ]
 then
 	VERSION=${VERSION}-dirty
 fi
 
-echo "-X $PACKAGE_PATH/version.Version=$VERSION"
+echo "-X $PACKAGE_PATH/version.version=$VERSION"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,56 @@
+package version
+
+import (
+	"errors"
+	"runtime/debug"
+)
+
+var (
+	Version string
+)
+
+type VCSInfo struct {
+	VCS          string
+	Revision     string
+	Date         string
+	TreeModified string
+}
+
+type Info struct {
+	Version   string
+	VCSInfo   VCSInfo
+	GoVersion string
+	Compiler  string
+	Platform  string
+}
+
+func GetBuildInfo() (*Info, error) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil, errors.New("version: Error in ReadBuildInfo")
+	}
+	result := &Info{
+		Version:   Version,
+		GoVersion: info.GoVersion,
+	}
+
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "-compiler":
+			result.Compiler = setting.Value
+		case "GOARCH":
+			result.Platform += setting.Value
+		case "GOOS":
+			result.Platform = setting.Value + "/" + result.Platform
+		case "vcs":
+			result.VCSInfo.VCS = setting.Value
+		case "vcs.revision":
+			result.VCSInfo.Revision = setting.Value
+		case "vcs.time":
+			result.VCSInfo.Date = setting.Value
+		case "vcs.modified":
+			result.VCSInfo.TreeModified = setting.Value
+		}
+	}
+	return result, nil
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package version
 
 import (
@@ -6,13 +10,13 @@ import (
 )
 
 var (
-	Version string
+	version string
 )
 
 type VCSInfo struct {
 	VCS          string
 	Revision     string
-	Date         string
+	Time         string
 	TreeModified string
 }
 
@@ -24,13 +28,13 @@ type Info struct {
 	Platform  string
 }
 
-func GetBuildInfo() (*Info, error) {
+func BuildInfo() (*Info, error) {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
 		return nil, errors.New("version: Error in ReadBuildInfo")
 	}
 	result := &Info{
-		Version:   Version,
+		Version:   version,
 		GoVersion: info.GoVersion,
 	}
 
@@ -47,7 +51,7 @@ func GetBuildInfo() (*Info, error) {
 		case "vcs.revision":
 			result.VCSInfo.Revision = setting.Value
 		case "vcs.time":
-			result.VCSInfo.Date = setting.Value
+			result.VCSInfo.Time = setting.Value
 		case "vcs.modified":
 			result.VCSInfo.TreeModified = setting.Value
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added flag --version which shows build info in json format:
```
{"Version":"v0.2.0-dev","VCSInfo":{"VCS":"git","Revision":"48acd2588150008737ac5f3840d13dc609ecf145","Date":"2022-08-03T14:42:34Z","TreeModified":"false"},"GoVersion":"go1.18.4","Compiler":"gc","Platform":"linux/amd64"}
```

**Which issue(s) this PR fixes**:
Fixes #8

**Special notes for your reviewer**:
In the Dockerfile before the build command I change to the directory of main.go because VCS info is missing in BuildInfo when running go build with a specified .go file

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Added `--version` flag that prints the server version information.
```
