### PR TITLE
 Build multi-arch images for amd64 and arm64

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -10,6 +10,10 @@ service-account-issuer-discovery:
       version:
         preprocess: inject-commit-hash
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           service-account-issuer-discovery:
             registry: 'gcr-readwrite'

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ COPY . .
 RUN go mod download
 
 # Build
+ARG TARGETARCH
 WORKDIR /workspace/cmd/service-account-issuer-discovery
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags="$(/workspace/hack/get-build.sh)" -o /workspace/service-account-issuer-discovery
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GO111MODULE=on go build -a -ldflags="$(/workspace/hack/get-build.sh)" -o /workspace/service-account-issuer-discovery
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /


### PR DESCRIPTION
**What this PR does / why we need it**:
 Build multi-arch images for amd64 and arm64

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The docker image for `service-account-issuer-discovery` is now multi-arch and supports `linux/arm64` and `linux/amd64` platforms.
```
