### PR TITLE
Bump golang to 1.19.5

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -19,7 +19,7 @@ service-account-issuer-discovery:
             tag_as_latest: false
     steps:
       verify:
-        image: 'golang:1.19.3'
+        image: 'golang:1.19.5'
   jobs:
     head-update:
       traits:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.19.3 AS builder
+FROM golang:1.19.5 AS builder
 
 WORKDIR /workspace
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump golang to 1.19.5

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`service-account-issuer-discovery` is now built using go version `1.19.5`.
```
