### PR TITLE
fix casing of automountKubeRootCA

### DIFF
--- a/charts/service-account-issuer-discovery/templates/deployment.yaml
+++ b/charts/service-account-issuer-discovery/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
           {{- toYaml .Values.resources | nindent 10 }}
         {{- if or ( or .Values.gardenerManagedDNS.enabled ( eq .Values.serviceType "LoadBalancer" ) ) .Values.tlsConfig.enabled }}
         volumeMounts:
-        {{- else if or ( or .Values.kubeconfig .Values.serviceAccountTokenVolumeProjection.enabled ) .Values.automountKubeRootCa }}
+        {{- else if or ( or .Values.kubeconfig .Values.serviceAccountTokenVolumeProjection.enabled ) .Values.automountKubeRootCA }}
         volumeMounts:
         {{- end }}
         {{- if or ( or .Values.gardenerManagedDNS.enabled ( eq .Values.serviceType "LoadBalancer" ) ) .Values.tlsConfig.enabled }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the casing of `automountKubeRootCa` to `automountKubeRootCA`  with uppercase `A` at the end in the if statement to align with the spelling in the values.yaml:
https://github.com/gardener/service-account-issuer-discovery/blob/b0fdd20db5ec1c274ca67da2858fe78f0cb21e98/charts/service-account-issuer-discovery/values.yaml#L16-L17


Otherwise when `automountKubeRootCA: true` is set in `values.yaml` it will fail with: 
```
Error: INSTALLATION FAILED: YAML parse error on service-account-issuer-discovery/templates/deployment.yaml: error converting YAML to JSON: yaml: line 69: did not find expected key
```

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix spelling of `automountKubeRootCA` in the helm chart.
```
