### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -3,9 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 service-account-issuer-discovery:
-  template: default
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess: inject-commit-hash
@@ -16,7 +14,6 @@ service-account-issuer-discovery:
         - linux/arm64
         dockerimages:
           service-account-issuer-discovery:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/service-account-issuer-discovery'
             dockerfile: Dockerfile
             tag_template: ${EFFECTIVE_VERSION}

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,6 +7,10 @@ service-account-issuer-discovery:
     traits:
       version:
         preprocess: inject-commit-hash
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
+        ocm_repository_mappings:
+          - repository: europe-docker.pkg.dev/gardener-project/releases
       publish:
         oci-builder: docker-buildx
         platforms:
@@ -14,7 +18,7 @@ service-account-issuer-discovery:
         - linux/arm64
         dockerimages:
           service-account-issuer-discovery:
-            image: 'eu.gcr.io/gardener-project/gardener/service-account-issuer-discovery'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/service-account-issuer-discovery
             dockerfile: Dockerfile
             tag_template: ${EFFECTIVE_VERSION}
             tag_as_latest: false
@@ -24,7 +28,6 @@ service-account-issuer-discovery:
   jobs:
     head-update:
       traits:
-        component_descriptor: ~
         draft_release: ~
         publish:
           dockerimages:
@@ -33,15 +36,15 @@ service-account-issuer-discovery:
     pull-request:
       traits:
         pull-request: ~
-        component_descriptor: ~
     release:
       traits:
         version:
           preprocess: finalize
         release:
           nextversion: bump_minor
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         publish:
           dockerimages:
             service-account-issuer-discovery:
-              tag_as_latest: false
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/service-account-issuer-discovery

--- a/charts/service-account-issuer-discovery/values.yaml
+++ b/charts/service-account-issuer-discovery/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 2
 
 image:
-  repository: eu.gcr.io/gardener-project/gardener/service-account-issuer-discovery
+  repository: europe-docker.pkg.dev/gardener-project/public/gardener/service-account-issuer-discovery
   tag: latest
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
