### PR TITLE
Fix HPA: replace autoscaling/v2beta2 with v2

### DIFF
--- a/charts/service-account-issuer-discovery/templates/hpa.yaml
+++ b/charts/service-account-issuer-discovery/templates/hpa.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.autoscaling.hpa.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "name" . }}


### PR DESCRIPTION
**What this PR does / why we need it**:
autoscaling/v2beta2 was deprecated in k8s v1.23 and removed in v1.26
=> replaced autoscaling/v2beta2 with autoscaling/v2
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126 

**Which issue(s) this PR fixes**:
HPA could not be used anymore from k8s v1.26 onwards

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
HPA definition in chart is fixed by replacing API version "autoscaling/v2beta2" with "autoscaling/v2".
```
