### PR TITLE
Update go and publish helm charts

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -24,7 +24,7 @@ service-account-issuer-discovery:
             tag_as_latest: false
     steps:
       verify:
-        image: 'golang:1.23.0'
+        image: 'golang:1.23.2'
   jobs:
     head-update:
       traits:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -3,6 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 service-account-issuer-discovery:
+  templates: 
+    helmcharts:
+    - &service-account-issuer-discovery
+      name: service-account-issuer-discovery
+      dir: charts/service-account-issuer-discovery
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener
+      mappings:
+      - ref: ocm-resource:service-account-issuer-discovery.repository
+        attribute: image.repository
+      - ref: ocm-resource:service-account-issuer-discovery.tag
+        attribute: image.tag
   base_definition:
     traits:
       version:
@@ -33,9 +44,14 @@ service-account-issuer-discovery:
           dockerimages:
             service-account-issuer-discovery:
               tag_as_latest: true
+          helmcharts:
+          - *service-account-issuer-discovery
     pull-request:
       traits:
         pull-request: ~
+        publish:
+          helmcharts:
+          - *service-account-issuer-discovery
     release:
       traits:
         version:
@@ -48,3 +64,6 @@ service-account-issuer-discovery:
           dockerimages:
             service-account-issuer-discovery:
               image: europe-docker.pkg.dev/gardener-project/releases/gardener/service-account-issuer-discovery
+          helmcharts:
+          - <<: *service-account-issuer-discovery
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.23.0 AS builder
+FROM golang:1.23.2 AS builder
 
 WORKDIR /workspace
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `service-account-issuer-discovery` server is now built using go version 1.23.2.
```

```feature operator
The helm chart of `service-account-issuer-discovery` is now published as OCI artifact.
```
