### PR TITLE
Add the option to configure a PodDisruptionBudget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Code editor specific directories
+.vscode

--- a/charts/service-account-issuer-discovery/templates/pdb.yaml
+++ b/charts/service-account-issuer-discovery/templates/pdb.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.resilience.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "name" . | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+{{- if not (kindIs "invalid" .Values.resilience.pdb.maxUnavailable) }}
+    maxUnavailable: {{ toYaml .Values.resilience.pdb.maxUnavailable }}
+{{- end }}
+{{- if not (kindIs "invalid" .Values.resilience.pdb.minAvailable) }}
+    minAvailable: {{ toYaml .Values.resilience.pdb.minAvailable }}
+{{- end }}
+    selector:
+      matchLabels:
+          app.kubernetes.io/name: {{ include "name" . | quote }}
+{{- end }}

--- a/charts/service-account-issuer-discovery/templates/pdb.yaml
+++ b/charts/service-account-issuer-discovery/templates/pdb.yaml
@@ -6,19 +6,19 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "name" . | quote }}
-  namespace: {{ .Release.Namespace | quote }}
+    name: {{ include "name" . }}
+    namespace: {{ .Release.Namespace }}
+labels:
+    app.kubernetes.io/name: {{ include "name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-{{- if not (kindIs "invalid" .Values.resilience.pdb.maxUnavailable) }}
-    maxUnavailable: {{ toYaml .Values.resilience.pdb.maxUnavailable }}
-{{- end }}
-{{- if not (kindIs "invalid" .Values.resilience.pdb.minAvailable) }}
-    minAvailable: {{ toYaml .Values.resilience.pdb.minAvailable }}
-{{- end }}
-{{- if .Values.resilience.pdb.unhealthyPodEvictionPolicy }}
-    unhealthyPodEvictionPolicy: {{ .Values.resilience.pdb.unhealthyPodEvictionPolicy | quote }}
+    maxUnavailable: 1
+{{- if semverCompare ">= 1.26-0" .Capabilities.KubeVersion.Version }}
+    unhealthyPodEvictionPolicy: AlwaysAllow
 {{- end }}
     selector:
-      matchLabels:
-          app.kubernetes.io/name: {{ include "name" . | quote }}
+        matchLabels:
+            app.kubernetes.io/name: {{ include "name" . }}
+            app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/service-account-issuer-discovery/templates/pdb.yaml
+++ b/charts/service-account-issuer-discovery/templates/pdb.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.resilience.pdb.enabled }}
+{{- if gt (int .Values.replicaCount) 1 }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -14,6 +14,9 @@ spec:
 {{- end }}
 {{- if not (kindIs "invalid" .Values.resilience.pdb.minAvailable) }}
     minAvailable: {{ toYaml .Values.resilience.pdb.minAvailable }}
+{{- end }}
+{{- if .Values.resilience.pdb.unhealthyPodEvictionPolicy }}
+    unhealthyPodEvictionPolicy: {{ .Values.resilience.pdb.unhealthyPodEvictionPolicy | quote }}
 {{- end }}
     selector:
       matchLabels:

--- a/charts/service-account-issuer-discovery/values.yaml
+++ b/charts/service-account-issuer-discovery/values.yaml
@@ -49,12 +49,6 @@ autoscaling:
     maxReplicas: 4
     cpuTargetAverageUtilization: 80
 
-resilience:
-  pdb:
-    maxUnavailable: 1
-    # minAvailable: "50%"
-    unhealthyPodEvictionPolicy: AlwaysAllow
-
 resources:
   requests:
     cpu: 50m

--- a/charts/service-account-issuer-discovery/values.yaml
+++ b/charts/service-account-issuer-discovery/values.yaml
@@ -51,9 +51,9 @@ autoscaling:
 
 resilience:
   pdb:
-    enabled: false
     maxUnavailable: 1
     # minAvailable: "50%"
+    unhealthyPodEvictionPolicy: AlwaysAllow
 
 resources:
   requests:

--- a/charts/service-account-issuer-discovery/values.yaml
+++ b/charts/service-account-issuer-discovery/values.yaml
@@ -49,6 +49,12 @@ autoscaling:
     maxReplicas: 4
     cpuTargetAverageUtilization: 80
 
+resilience:
+  pdb:
+    enabled: false
+    maxUnavailable: 1
+    # minAvailable: "50%"
+
 resources:
   requests:
     cpu: 50m


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the option to configure a PodDisruptionBudget via the values.yaml to make the sa-issuer-discovery deployment more resilient.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Added the option to configure a PodDisruptionBudget via the helm chart values.
```
