### PR TITLE
Add Values Options for "imagePullSecrets", "priorityClassName", "topologySpreadConstraints"

### DIFF
--- a/charts/service-account-issuer-discovery/templates/deployment.yaml
+++ b/charts/service-account-issuer-discovery/templates/deployment.yaml
@@ -45,6 +45,13 @@ spec:
                 - {{ .Release.Name }}
             topologyKey: "kubernetes.io/hostname"
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
       serviceAccountName: {{ include "name" . }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       containers:

--- a/charts/service-account-issuer-discovery/values.yaml
+++ b/charts/service-account-issuer-discovery/values.yaml
@@ -9,6 +9,8 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
+imagePullSecrets: []
+
 kubeconfig:
 
 automountServiceAccountToken: false
@@ -48,6 +50,9 @@ autoscaling:
     minReplicas: 2
     maxReplicas: 4
     cpuTargetAverageUtilization: 80
+
+priorityClassName: ""
+topologySpreadConstraints: []
 
 resources:
   requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add values for "imagePullSecrets", "priorityClassName", "topologySpreadConstraints" to the sa-issuer-discovery chart.
This allows consumers of the chart to pull the image from a private mirror, as well as to specify priority classes and (e.g. zone) topologySpreadConstraints to implement HA.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
"imagePullSecrets", "priorityClassName" and "topologySpreadConstraints" are now configurable via the values file of the service-account-issuer-discovery chart.
```
