### PR TITLE
Enable gosec for SAST scans

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 service-account-issuer-discovery:
-  templates: 
+  templates:
     helmcharts:
     - &service-account-issuer-discovery
       name: service-account-issuer-discovery
@@ -15,6 +15,13 @@ service-account-issuer-discovery:
       - ref: ocm-resource:service-account-issuer-discovery.tag
         attribute: image.tag
   base_definition:
+    repo:
+      source_labels:
+      - name: cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1
+        value:
+          policy: skip
+          comment: |
+            We use gosec for sast scanning, see attached log.
     traits:
       version:
         preprocess: inject-commit-hash
@@ -58,6 +65,16 @@ service-account-issuer-discovery:
           preprocess: finalize
         release:
           nextversion: bump_minor
+          assets:
+          - type: build-step-log
+            step_name: verify
+            purposes:
+            - lint
+            - sast
+            - gosec
+            comment: |
+              We use gosec (linter) for SAST scans, see: https://github.com/securego/gosec.
+              Enabled by https://github.com/gardener/service-account-issuer-discovery/pull/42
         component_descriptor:
           ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         publish:

--- a/.ci/verify
+++ b/.ci/verify
@@ -17,6 +17,8 @@ fi
 
 cd "${SOURCE_PATH}"
 
+go install github.com/securego/gosec/v2/cmd/gosec@v2.21.4
+
 make verify
 
 curl -s "https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3" | bash -s -- --version 'v3.5.4'

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # Code editor specific directories
 .vscode
+
+# gosec
+gosec-report.sarif

--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,12 @@ test:
 	@go test -cover ./...
 
 .PHONY: verify
-verify: check test
+verify: check test sast
+
+.PHONY: sast
+sast:
+	@./hack/sast.sh
+
+.PHONY: sast-report
+sast-report:
+	@./hack/sast.sh --gosec-report true

--- a/cmd/service-account-issuer-discovery/main.go
+++ b/cmd/service-account-issuer-discovery/main.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/gardener/service-account-issuer-discovery/internal/app"
@@ -126,7 +127,7 @@ func getRESTConfig() (*rest.Config, error) {
 	}
 
 	if len(kubeconfigFilePath) != 0 {
-		kubeconfigBytes, err := os.ReadFile(kubeconfigFilePath)
+		kubeconfigBytes, err := os.ReadFile(filepath.Clean(kubeconfigFilePath))
 		if err != nil {
 			return nil, err
 		}

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+
+gosec_report="false"
+gosec_report_parse_flags=""
+
+parse_flags() {
+  while test $# -gt 1; do
+    case "$1" in
+      --gosec-report)
+        shift; gosec_report="$1"
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+parse_flags "$@"
+
+echo "> Running gosec"
+gosec --version
+if [[ "$gosec_report" != "false" ]]; then
+  echo "Exporting report to $root_dir/gosec-report.sarif"
+  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout"
+fi
+
+gosec  $gosec_report_parse_flags ./...

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -98,7 +98,9 @@ func (s *handlersSet) Config(w http.ResponseWriter, r *http.Request) {
 	cached := s.cacher.Get(configKey)
 	if cached != nil {
 		w.Header().Add("Content-Type", "application/json")
-		w.Write(cached)
+		if _, err := w.Write(cached); err != nil {
+			s.logger.Println(err)
+		}
 		return
 	}
 
@@ -139,7 +141,9 @@ func (s *handlersSet) Config(w http.ResponseWriter, r *http.Request) {
 	bytes := v.([]byte)
 	s.cacher.Update(configKey, bytes)
 	w.Header().Add("Content-Type", "application/json")
-	w.Write(bytes)
+	if _, err := w.Write(bytes); err != nil {
+		s.logger.Println(err)
+	}
 }
 
 func (s *handlersSet) JWKS(w http.ResponseWriter, r *http.Request) {
@@ -151,7 +155,9 @@ func (s *handlersSet) JWKS(w http.ResponseWriter, r *http.Request) {
 	cached := s.cacher.Get(jwksKey)
 	if cached != nil {
 		w.Header().Add("Content-Type", "application/json")
-		w.Write(cached)
+		if _, err := w.Write(cached); err != nil {
+			s.logger.Println(err)
+		}
 		return
 	}
 
@@ -184,7 +190,9 @@ func (s *handlersSet) JWKS(w http.ResponseWriter, r *http.Request) {
 	jwksBytes := v.([]byte)
 	s.cacher.Update(jwksKey, jwksBytes)
 	w.Header().Add("Content-Type", "application/json")
-	w.Write(jwksBytes)
+	if _, err := w.Write(jwksBytes); err != nil {
+		s.logger.Println(err)
+	}
 }
 
 func (s *handlersSet) Healthz(w http.ResponseWriter, r *http.Request) {
@@ -193,7 +201,9 @@ func (s *handlersSet) Healthz(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Write([]byte("ok"))
+	if _, err := w.Write([]byte("ok")); err != nil {
+		s.logger.Println(err)
+	}
 }
 
 type oidConfig struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable `gosec` for SAST scans

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->


```other developer
`gosec` is made available for SAST(static application security testing), it can be run with `make sast` or `make sast-report`, but is also incorporated in the `verify` makefile target. 
```
