### PR TITLE
Add Helm & Container image urls to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,24 @@ Work in progress... Partial documentation ahead.
 ### Quick start
 
 To run the server with minimal configuration export the `KUBECONFIG` environment variable and run:
-``` 
+```
 go run ./cmd/service-account-issuer-discovery/main.go --hostname=<issuer-of-cluster>
 ```
 Or pass the `kubeconfig` as a flag:
-``` 
+```
 go run ./cmd/service-account-issuer-discovery/main.go --kubeconfig=<path-to-my-kubeconfig> --hostname=<issuer-of-cluster>
 ```
 
 Retrieve the `well-known` document by querying `/.well-known/openid-configuration`.
+
+### Helm Charts
+
+service-account-issuer-discovery
+
+* europe-docker.pkg.dev/gardener-project/releases/charts/gardener/service-account-issuer-discovery:VERSION
+
+### Container Images
+
+service-account-issuer-discovery
+
+* europe-docker.pkg.dev/gardener-project/releases/gardener/service-account-issuer-discovery:VERSION

--- a/README.md
+++ b/README.md
@@ -18,14 +18,7 @@ go run ./cmd/service-account-issuer-discovery/main.go --kubeconfig=<path-to-my-k
 
 Retrieve the `well-known` document by querying `/.well-known/openid-configuration`.
 
-### Helm Charts
+### Container Images and Helm Charts
 
-service-account-issuer-discovery
-
-* europe-docker.pkg.dev/gardener-project/releases/charts/gardener/service-account-issuer-discovery:VERSION
-
-### Container Images
-
-service-account-issuer-discovery
-
-* europe-docker.pkg.dev/gardener-project/releases/gardener/service-account-issuer-discovery:VERSION
+Details of the available container images and Helm charts can be found under
+[Releases](https://github.com/gardener/service-account-issuer-discovery/releases/).


### PR DESCRIPTION
**What this PR does / why we need it**:

URLs of Helm charts and container images are currently only available on some old releases:
* https://github.com/gardener/service-account-issuer-discovery/releases/tag/v0.8.0

README would be a friendly location.

**Release note**:

NONE 

