### PR TITLE
Update gosec dependency to v2.22.8

### DIFF
--- a/.ci/verify
+++ b/.ci/verify
@@ -17,7 +17,7 @@ fi
 
 cd "${SOURCE_PATH}"
 
-go install github.com/securego/gosec/v2/cmd/gosec@v2.21.4
+go install github.com/securego/gosec/v2/cmd/gosec@v2.22.8
 
 make verify
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The verify step in the `main` branch is currently failing https://concourse.ci.gardener.cloud/teams/gardener/pipelines/service-account-issuer-discovery-master/jobs/master-head-update-job/builds/41.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
Update `gosec` dependency to v2.22.8
```
