### PR TITLE
Various improvements in GHA setup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,7 @@ jobs:
     name: Build OCI-Images
     needs:
       - prepare
+      - verify
     permissions:
       contents: read
       packages: write
@@ -80,7 +81,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
       - name: run-verify
         run: |
@@ -109,4 +110,4 @@ jobs:
                 value: |
                   we use gosec (linter) for SAST scans
                   see: https://github.com/securego/gosec
-                  Enabled by https://github.com/gardener/gardener-discovery-server/pull/70
+                  Enabled by https://github.com/gardener/service-account-issuer-discovery/pull/42

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -1,4 +1,4 @@
-name: Build
+name: Non-Release
 on:
   push:
   pull_request:

--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
-#
-# SPDX-License-Identifier: Apache-2.0
-
 main-source:
   labels:
     - name: cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.25.0 AS builder
+FROM golang:1.25.5 AS builder
 
 WORKDIR /workspace
 COPY . .

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -4,13 +4,13 @@ SPDX-PackageSupplier = "The Gardener project <gardener@googlegroups.com>"
 SPDX-PackageDownloadLocation = "https://github.com/gardener/service-account-issuer-discovery"
 
 [[annotations]]
-path = [".ci/**", ".github/**", ".gitignore", "charts/service-account-issuer-discovery/.helmignore", "charts/service-account-issuer-discovery/templates/_helpers.tpl", "CODEOWNERS", "OWNERS", "OWNERS_ALIASES", "go.mod", "go.sum", "VERSION"]
+path = [".ci/**", ".github/**", ".ocm/**", ".gitignore", "charts/service-account-issuer-discovery/.helmignore", "charts/service-account-issuer-discovery/templates/_helpers.tpl", "CODEOWNERS", "OWNERS", "OWNERS_ALIASES", "go.mod", "go.sum", "VERSION"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2022-2025 SAP SE or an SAP affiliate company and Gardener contributors"
+SPDX-FileCopyrightText = "SAP SE or an SAP affiliate company and Gardener contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["CONTRIBUTING.md", "README.md"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2022-2025 SAP SE or an SAP affiliate company and Gardener contributors"
+SPDX-FileCopyrightText = "SAP SE or an SAP affiliate company and Gardener contributors"
 SPDX-License-Identifier = "CC-BY-4.0"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,11 +6,11 @@ SPDX-PackageDownloadLocation = "https://github.com/gardener/service-account-issu
 [[annotations]]
 path = [".ci/**", ".github/**", ".gitignore", "charts/service-account-issuer-discovery/.helmignore", "charts/service-account-issuer-discovery/templates/_helpers.tpl", "CODEOWNERS", "OWNERS", "OWNERS_ALIASES", "go.mod", "go.sum", "VERSION"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2022 SAP SE or an SAP affiliate company and Gardener contributors"
+SPDX-FileCopyrightText = "2022-2025 SAP SE or an SAP affiliate company and Gardener contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["CONTRIBUTING.md", "README.md"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2022 SAP SE or an SAP affiliate company and Gardener contributors"
+SPDX-FileCopyrightText = "2022-2025 SAP SE or an SAP affiliate company and Gardener contributors"
 SPDX-License-Identifier = "CC-BY-4.0"


### PR DESCRIPTION
**What this PR does / why we need it**:
Some additions on top of https://github.com/gardener/service-account-issuer-discovery/pull/55
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `service-account-issuer-discovery` server is built using go version `1.25.5`.
```
