### PR TITLE
added gardenerManagedCertificate

### DIFF
--- a/charts/service-account-issuer-discovery/templates/_helpers.tpl
+++ b/charts/service-account-issuer-discovery/templates/_helpers.tpl
@@ -1,3 +1,9 @@
 {{- define "name" -}}
 service-account-issuer-discovery
 {{- end -}}
+
+{{- define "tlsEnabled" -}}
+{{- if or .Values.gardenerManagedDNS.enabled .Values.gardenerManagedCertificate.enabled ( eq .Values.serviceType "LoadBalancer" ) .Values.tlsConfig.enabled -}}
+true
+{{- end -}}
+{{- end -}}

--- a/charts/service-account-issuer-discovery/templates/certificate.yaml
+++ b/charts/service-account-issuer-discovery/templates/certificate.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/charts/service-account-issuer-discovery/templates/certificate.yaml
+++ b/charts/service-account-issuer-discovery/templates/certificate.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.gardenerManagedCertificate.enabled .Values.gardenerManagedDNS.enabled }}
+{{- fail "gardenerManagedDNS.enabled and gardenerManagedCertificate.enabled are mutually exclusive: gardenerManagedDNS already requests a certificate. Enable only one." }}
+{{- end }}
+{{- if .Values.gardenerManagedCertificate.enabled }}
+apiVersion: cert.gardener.cloud/v1alpha1
+kind: Certificate
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  commonName: {{ required ".Values.hostname is required" .Values.hostname }}
+  {{- if .Values.gardenerManagedCertificate.issuerName }}
+  issuerRef:
+    name: {{ .Values.gardenerManagedCertificate.issuerName }}
+  {{- end }}
+  secretRef:
+    name: {{ include "name" . }}-tls
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/service-account-issuer-discovery/templates/deployment.yaml
+++ b/charts/service-account-issuer-discovery/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           {{- toYaml .Values.containerSecurityContext | nindent 10 }}
         {{- end }}
         args:
-        {{- if or ( or .Values.gardenerManagedDNS.enabled ( eq .Values.serviceType "LoadBalancer" ) ) .Values.tlsConfig.enabled }}
+        {{- if include "tlsEnabled" . }}
         - --cert-file=/var/run/issuer-discovery/tls/tls.crt
         - --key-file=/var/run/issuer-discovery/tls/tls.key
         {{- end }}
@@ -81,7 +81,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10443
-            {{- if or ( or .Values.gardenerManagedDNS.enabled ( eq .Values.serviceType "LoadBalancer" ) ) .Values.tlsConfig.enabled }}
+            {{- if include "tlsEnabled" . }}
             scheme: HTTPS
             {{- else }}
             scheme: HTTP
@@ -90,12 +90,12 @@ spec:
           periodSeconds: 20
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        {{- if or ( or .Values.gardenerManagedDNS.enabled ( eq .Values.serviceType "LoadBalancer" ) ) .Values.tlsConfig.enabled }}
+        {{- if include "tlsEnabled" . }}
         volumeMounts:
         {{- else if or ( or .Values.kubeconfig .Values.serviceAccountTokenVolumeProjection.enabled ) .Values.automountKubeRootCA }}
         volumeMounts:
         {{- end }}
-        {{- if or ( or .Values.gardenerManagedDNS.enabled ( eq .Values.serviceType "LoadBalancer" ) ) .Values.tlsConfig.enabled }}
+        {{- if include "tlsEnabled" . }}
         - name: tls
           mountPath: /var/run/issuer-discovery/tls
           readOnly: true
@@ -115,12 +115,12 @@ spec:
           mountPath: /var/run/issuer-discovery/kube-root-ca
           readOnly: true
         {{- end }}
-      {{- if or ( or .Values.gardenerManagedDNS.enabled ( eq .Values.serviceType "LoadBalancer" ) ) .Values.tlsConfig.enabled }}
+      {{- if include "tlsEnabled" . }}
       volumes:
       {{- else if or ( or .Values.kubeconfig .Values.serviceAccountTokenVolumeProjection.enabled ) .Values.automountKubeRootCA }}
       volumes:
       {{- end }}
-      {{- if or ( or .Values.gardenerManagedDNS.enabled ( eq .Values.serviceType "LoadBalancer" ) ) .Values.tlsConfig.enabled }}
+      {{- if include "tlsEnabled" . }}
       - name: tls
         projected:
           sources:

--- a/charts/service-account-issuer-discovery/templates/secret-tls.yaml
+++ b/charts/service-account-issuer-discovery/templates/secret-tls.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if not .Values.gardenerManagedDNS.enabled }}
+{{- if and ( not .Values.gardenerManagedDNS.enabled ) ( not .Values.gardenerManagedCertificate.enabled ) }}
 {{- if or ( eq .Values.serviceType "LoadBalancer" ) .Values.tlsConfig.enabled }}
 apiVersion: v1
 kind: Secret

--- a/charts/service-account-issuer-discovery/values.yaml
+++ b/charts/service-account-issuer-discovery/values.yaml
@@ -32,7 +32,12 @@ hostname: ""
 gardenerManagedDNS:
   enabled: false
 
-# If gardenerManagedDNS.enabled is set to true then tlsConfig is ignored.
+# Requests a Gardener-managed certificate without DNS. Mutually exclusive with gardenerManagedDNS.
+gardenerManagedCertificate:
+  enabled: false
+  issuerName: ""
+
+# If gardenerManagedDNS.enabled or gardenerManagedCertificate.enabled is set to true then tlsConfig is ignored.
 tlsConfig:
   enabled: false
   crt: |


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds a `gardenerManagedCertificate` Helm chart value that requests a Gardener-managed certificate without Gardener-managed DNS records - the certificate-only counterpart to `gardenerManagedDNS`.
* Enables running service-account-issuer-discovery behind a Gateway with TLS passthrough, where DNS is handled elsewhere.
* Mutually exclusive with `gardenerManagedDNS` (enabling both fails rendering with a clear error).

**Release note**:

```feature user
Added Helm chart value gardenerManagedCertificate to request a certificate without Gardener-managed DNS records
```
